### PR TITLE
Validação de token

### DIFF
--- a/src/graphql/schema/user/dataSources.ts
+++ b/src/graphql/schema/user/dataSources.ts
@@ -1,5 +1,4 @@
 import bcrypt from 'bcrypt'
-import jwt from 'jsonwebtoken'
 import { User } from '@prisma/client'
 
 import { prisma } from '@services/prisma'
@@ -65,16 +64,7 @@ export class UserDataSource {
 
     const passwordHash = await bcrypt.hash(password, 12)
 
-    const token = jwt.sign({ email }, process.env.TOKEN_SECRET_KEY, {
-      expiresIn: '1d',
-    })
-    const refresh_token = jwt.sign(
-      { email },
-      process.env.REFRESH_TOKEN_SECRET_KEY,
-      {
-        expiresIn: '7d',
-      },
-    )
+    const { token, refresh_token } = createNewTokenAndRefreshToken(email)
 
     return await prisma.user.create({
       data: { email, password: passwordHash, token, refresh_token },

--- a/src/graphql/schema/user/dataSources.ts
+++ b/src/graphql/schema/user/dataSources.ts
@@ -4,7 +4,7 @@ import { User } from '@prisma/client'
 
 import { prisma } from '@services/prisma'
 import { AppError } from '@utils/appError'
-import { createNewTokenAndRefreshToken, refreshTokenIsValid } from '@utils/jts'
+import { createNewTokenAndRefreshToken, refreshTokenIsValid } from '@utils/jwt'
 
 export class UserDataSource {
   async login(data: {

--- a/src/graphql/schema/user/resolvers.ts
+++ b/src/graphql/schema/user/resolvers.ts
@@ -1,4 +1,5 @@
 import { Context } from '@schema/context'
+import { getRefreshTokenValueFromCookie } from '@utils/jwt'
 
 /**
  * @async
@@ -14,11 +15,6 @@ const login = async (
   const { token, refresh_token, ...rest } = await dataSources.user.login({
     ...loginInput,
   })
-
-  res.setHeader('Set-Cookie', [
-    `token=${token}`,
-    `refresh_token=${refresh_token}`,
-  ])
 
   return { token, refresh_token, ...rest }
 }
@@ -42,11 +38,7 @@ const register = async (
  * @returns {{token: string, refresh_token: string}} - retorna um objeto com o novo token e refresh token
  */
 const refreshToken = async (_, __, { dataSources, req }: Context) => {
-  const refresh_token = req.headers.cookie
-    ?.split('; ')
-    ?.find((cookie) => cookie.startsWith('refresh_token='))
-    ?.split('=')[1]
-
+  const refresh_token = getRefreshTokenValueFromCookie(req.headers.cookie)
   return await dataSources.user.refresh_token(refresh_token)
 }
 

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -70,11 +70,9 @@ const userIsAuthenticated = (cookie: string) => {
       ?.find((cookie) => cookie.startsWith('token='))
       ?.split('=')[1]
 
-    const payload = jwt.verify(token, process.env.TOKEN_SECRET_KEY, {
+    jwt.verify(token, process.env.TOKEN_SECRET_KEY, {
       ignoreExpiration: false,
-    }) as { email: string }
-
-    return !!payload.email
+    })
   } catch (err) {
     if (err instanceof TokenExpiredError)
       throw new AppError('Token expirado', 'BAD_REQUEST')

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -58,4 +58,39 @@ const createNewTokenAndRefreshToken = (email: string) => {
   return { token, refresh_token }
 }
 
-export { tokenIsValid, refreshTokenIsValid, createNewTokenAndRefreshToken }
+/**
+ * @function userIsAuthenticated - verifica se o token está presente nos cookies se é válido
+ * @returns {boolean} - se o token for estiver presente nos cookies e for válido é retornado um boolean
+ * com valor 'true', caso contrário um erro é lançado
+ */
+const userIsAuthenticated = (cookie: string) => {
+  const token = cookie
+    ?.split('; ')
+    ?.find((cookie) => cookie.startsWith('token='))
+    ?.split('=')[1]
+
+  const payload = jwt.verify(token, process.env.TOKEN_SECRET_KEY)
+
+  console.log(!!payload)
+}
+
+/**
+ * @function getRefreshTokenValueFromCookie - obtém o refresh token dos cookies
+ * @returns {boolean} - retorna o valor do refresh token
+ */
+const getRefreshTokenValueFromCookie = (cookie: string) => {
+  const refresh_token = cookie
+    ?.split('; ')
+    ?.find((cookie) => cookie.startsWith('refresh_token='))
+    ?.split('=')[1]
+
+  return refresh_token
+}
+
+export {
+  tokenIsValid,
+  refreshTokenIsValid,
+  userIsAuthenticated,
+  getRefreshTokenValueFromCookie,
+  createNewTokenAndRefreshToken,
+}


### PR DESCRIPTION
adicionada validação de token enviada pelo cookie, caso o token seja inválido com a assinatura usada na criação ou o token esteja expirado um erro é lançado e o usuário é barrado de prosseguir com a requisição.

caso o token sejá válido com a assinatura usada na criação e nao esteja expirado, o usuário pode prosseguir com a requisição feita.

a aplicação está prota para iniar os resolver privados uma vez que há uma função que faz esse verificação de autenticação!