### PR TITLE
Adiciona querys iniciais de tasks

### DIFF
--- a/src/graphql/schema/task/datasource.ts
+++ b/src/graphql/schema/task/datasource.ts
@@ -61,4 +61,15 @@ export class TaskDataSource {
 
     return tasksList.length
   }
+
+  async totalUserCompletedTasks(userId: number) {
+    if (!userId)
+      throw new AppError('O id do usuário é obrigatório', 'BAD_REQUEST')
+
+    const completedTasksList = await prisma.task.findMany({
+      where: { userId, AND: { status: 'CONPLETED' } },
+    })
+
+    return completedTasksList.length
+  }
 }

--- a/src/graphql/schema/task/datasource.ts
+++ b/src/graphql/schema/task/datasource.ts
@@ -72,4 +72,15 @@ export class TaskDataSource {
 
     return completedTasksList.length
   }
+
+  async totalUserPendingTasks(userId: number) {
+    if (!userId)
+      throw new AppError('O id do usuário é obrigatório', 'BAD_REQUEST')
+
+    const pendingTasksList = await prisma.task.findMany({
+      where: { userId, AND: { status: 'PENDING' } },
+    })
+
+    return pendingTasksList.length
+  }
 }

--- a/src/graphql/schema/task/datasource.ts
+++ b/src/graphql/schema/task/datasource.ts
@@ -52,4 +52,13 @@ export class TaskDataSource {
 
     return await prisma.task.create({ data })
   }
+
+  async totalUserTasks(userId: number) {
+    if (!userId)
+      throw new AppError('O id do usuário é obrigatório', 'BAD_REQUEST')
+
+    const tasksList = await prisma.task.findMany({ where: { userId } })
+
+    return tasksList.length
+  }
 }

--- a/src/graphql/schema/task/resolvers.ts
+++ b/src/graphql/schema/task/resolvers.ts
@@ -48,7 +48,22 @@ const totalUserCompletedTasks = (
   return dataSources.task.totalUserCompletedTasks(userId)
 }
 
+/**
+ * @async
+ * @function totalUserPendingTasks - função responsável por retornar quantidade de tasks o usuário ainda precisa fazer
+ * @returns {{totalUserPendingTasks: number}} - retorna um objeto contendo o quantitativo de tasks o usuário ainda
+ * precisa fazer
+ */
+const totalUserPendingTasks = (
+  _,
+  { userId }: { userId: number },
+  { dataSources, req }: Context,
+) => {
+  userIsAuthenticated(req.headers.cookie)
+  return dataSources.task.totalUserPendingTasks(userId)
+}
+
 export const taksResolvers = {
-  Query: { totalUserTasks, totalUserCompletedTasks },
+  Query: { totalUserTasks, totalUserCompletedTasks, totalUserPendingTasks },
   Mutation: { createTask },
 }

--- a/src/graphql/schema/task/resolvers.ts
+++ b/src/graphql/schema/task/resolvers.ts
@@ -33,7 +33,22 @@ const totalUserTasks = (
   return dataSources.task.totalUserTasks(userId)
 }
 
+/**
+ * @async
+ * @function totalUserCompletedTasks - função responsável por retornar quantidade de tasks o usuário já completou
+ * @returns {{totalUserCompletedTasks: number}} - retorna um objeto contendo o quantitativo de tasks completas
+ * pelo usuário
+ */
+const totalUserCompletedTasks = (
+  _,
+  { userId }: { userId: number },
+  { dataSources, req }: Context,
+) => {
+  userIsAuthenticated(req.headers.cookie)
+  return dataSources.task.totalUserCompletedTasks(userId)
+}
+
 export const taksResolvers = {
-  Query: { totalUserTasks },
+  Query: { totalUserTasks, totalUserCompletedTasks },
   Mutation: { createTask },
 }

--- a/src/graphql/schema/task/resolvers.ts
+++ b/src/graphql/schema/task/resolvers.ts
@@ -18,6 +18,22 @@ const createTask = (
   return dataSources.task.createTask(createTaskInput)
 }
 
+/**
+ * @async
+ * @function totalUserTasks - função responsável por retornar a quantidade de tasks associadas a um usuário
+ * @returns {{totalUserTasks: number}} - retorna um objeto contendo o quantitativo de tasks associadas a
+ * um usuário
+ */
+const totalUserTasks = (
+  _,
+  { userId }: { userId: number },
+  { dataSources, req }: Context,
+) => {
+  userIsAuthenticated(req.headers.cookie)
+  return dataSources.task.totalUserTasks(userId)
+}
+
 export const taksResolvers = {
+  Query: { totalUserTasks },
   Mutation: { createTask },
 }

--- a/src/graphql/schema/task/typeDefs.ts
+++ b/src/graphql/schema/task/typeDefs.ts
@@ -1,6 +1,7 @@
 export const taskTypeDefs = `#graphql
   type Query {
     totalUserTasks(userId: Int!): Int!
+    totalUserCompletedTasks(userId: Int!): Int!
   }
 
   type Mutation {

--- a/src/graphql/schema/task/typeDefs.ts
+++ b/src/graphql/schema/task/typeDefs.ts
@@ -2,6 +2,7 @@ export const taskTypeDefs = `#graphql
   type Query {
     totalUserTasks(userId: Int!): Int!
     totalUserCompletedTasks(userId: Int!): Int!
+    totalUserPendingTasks(userId: Int!): Int!
   }
 
   type Mutation {

--- a/src/graphql/schema/task/typeDefs.ts
+++ b/src/graphql/schema/task/typeDefs.ts
@@ -1,4 +1,8 @@
 export const taskTypeDefs = `#graphql
+  type Query {
+    totalUserTasks(userId: Int!): Int!
+  }
+
   type Mutation {
     createTask(createTaskInput: CreateTaskInput!): Task!
   }


### PR DESCRIPTION
adicionadas querys para:

- obter o quantitativo total de tasks já atribuidas a um usuário
- obter o quantitativo total de tasks já completas por um usuário
- obter o quantitativo total de tasks atribuidas a um usuário e que estão com status de pendente